### PR TITLE
Rbx4/italia irredenta

### DIFF
--- a/PFH/decisions/Italy.txt
+++ b/PFH/decisions/Italy.txt
@@ -675,8 +675,34 @@ political_decisions = {
 			is_greater_power = yes
 			OR = {
 				729 = { NOT = { is_core = ITA } } #Venice
-				736 = { NOT = { is_core = ITA } } #Triest
-				734 = { NOT = { is_core = ITA } } #Trient
+				AND = {
+					736 = { NOT = { is_core = ITA } } #Triest
+					734 = { NOT = { is_core = ITA } } #Trient
+					random_owned = {
+						limit = {
+							province_id = 729 #Venetia
+							owner = { 
+								OR = {
+									AND = {
+										ai = no
+										nationalism_n_imperialism = 1
+									}
+									mass_politics = 1
+									great_wars_enabled = yes
+									734 = { #Trient
+										owner = {
+											NOT = { is_culture_group = italian }
+											OR = {
+												is_greater_power = no
+												is_disarmed = yes
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
 				AND = {
 					721 = { NOT = { is_core = ITA } } #Aosta
 					random_owned = {

--- a/PFH/decisions/Italy.txt
+++ b/PFH/decisions/Italy.txt
@@ -678,69 +678,59 @@ political_decisions = {
 				AND = {
 					736 = { NOT = { is_core = ITA } } #Triest
 					734 = { NOT = { is_core = ITA } } #Trient
-					random_owned = {
-						limit = {
-							province_id = 729 #Venetia
-							owner = { 
+					OR = {
+						THIS = {
+							owns = 729  #Venetia
+							OR = {
+								AND = {
+									ai = no
+									nationalism_n_imperialism = 1
+								}
+								mass_politics = 1
+								great_wars_enabled = yes
+							}
+						}
+						734 = {
+							owner = {
+								NOT = { is_culture_group = italian }
 								OR = {
-									AND = {
-										ai = no
-										nationalism_n_imperialism = 1
-									}
-									mass_politics = 1
-									great_wars_enabled = yes
-									734 = { #Trient
-										owner = {
-											NOT = { is_culture_group = italian }
-											OR = {
-												is_greater_power = no
-												is_disarmed = yes
-											}
-										}
-									}
+									is_greater_power = no
+									is_disarmed = yes
 								}
 							}
 						}
 					}
 				}
 				AND = {
-					721 = { NOT = { is_core = ITA } } #Aosta
-					random_owned = {
-						limit = {
-							owner = {
-								is_culture_group = italian
-								has_global_flag = the_treaty_of_milan
-								NOT = { 
-									truce_with = FRA
-									truce_with = BOR
-								}	
+					THIS = {
+						is_culture_group = italian
+						OR = {
+							NOT = { has_global_flag = plombieres }
+							has_global_flag = the_treaty_of_milan
+							has_global_flag = france_dismantled
+							has_country_flag = in_great_war
+							AND = {
+								ai = no
+								nationalism_n_imperialism = 1
 							}
+						}
+						NOT = {
+							truce_with = FRA
+							truce_with = BOR
 						}	
 					}
+					465 = { NOT = { is_core = ITA } } #Savoia
 				}
 				AND = {
-					465 = { NOT = { is_core = ITA } } #Savoia
-					random_owned = {
-						limit = {
-							owner = {
-								is_culture_group = italian
-								OR = {
-									NOT = { has_global_flag = plombieres }
-									has_global_flag = the_treaty_of_milan
-									has_global_flag = france_dismantled
-									has_country_flag = in_great_war
-									AND = {
-										ai = no
-										nationalism_n_imperialism = 1
-									}
-								}
-								NOT = {
-									truce_with = FRA
-									truce_with = BOR
-								}	
-							}
-						}
+					THIS = {
+						is_culture_group = italian
+						has_global_flag = the_treaty_of_milan
+						NOT = { 
+							truce_with = FRA
+							truce_with = BOR
+						}	
 					}
+					721 = { NOT = { is_core = ITA } } #Aosta
 				}
 			}
 		}
@@ -751,8 +741,10 @@ political_decisions = {
 				limit = {
 					province_id = 727 #Lombardy
 				}
-				AUS_729 = { add_core = ITA }
-				owner = { set_global_flag = italian_claimed_venetia }
+				owner = { 
+					set_global_flag = italian_claimed_venetia
+					729 = { add_core = ITA }
+				}
 			}
 			
 			#Claim Trieste & South Tirol
@@ -779,9 +771,10 @@ political_decisions = {
 						}
 					}
 				}
-				AUS_734 = { add_core = ITA remove_core = TST }
-				AUS_736 = { add_core = ITA }
-				owner = { set_global_flag = italian_claimed_venetia }
+				734 = { add_core = ITA remove_core = TST }
+				736 = { add_core = ITA }
+				owner = { set_global_flag = italian_claimed_venetia 
+				}
 			}
 			
 			#Claim Savoia

--- a/PFH/decisions/Italy.txt
+++ b/PFH/decisions/Italy.txt
@@ -630,7 +630,7 @@ political_decisions = {
 						ai = no
 						mass_politics = 1
 						great_wars_enabled = yes
-						721 = { #Trient
+						721 = { #Aosta
 							owner = {
 								NOT = { is_culture_group = italian }
 								OR = {
@@ -674,7 +674,12 @@ political_decisions = {
 			invention = national_fraternity
 			is_greater_power = yes
 			OR = {
-				729 = { NOT = { is_core = ITA } } #Venice
+				AND = {
+					729 = { NOT = { is_core = ITA } } #Venice
+					owns = 727 #Lombardy
+					NOT = { has_global_flag = italian_claimed_venetia}
+				}
+				
 				AND = {
 					736 = { NOT = { is_core = ITA } } #Triest
 					734 = { NOT = { is_core = ITA } } #Trient
@@ -700,10 +705,12 @@ political_decisions = {
 							}
 						}
 					}
+					NOT = {has_global_flag = italian_claimed_south_tirol}
 				}
+				
 				AND = {
+					465 = { NOT = { is_core = ITA } } #Savoia
 					THIS = {
-						is_culture_group = italian
 						OR = {
 							NOT = { has_global_flag = plombieres }
 							has_global_flag = the_treaty_of_milan
@@ -719,18 +726,17 @@ political_decisions = {
 							truce_with = BOR
 						}	
 					}
-					465 = { NOT = { is_core = ITA } } #Savoia
 				}
+				
 				AND = {
+					721 = { NOT = { is_core = ITA } } #Aosta
 					THIS = {
-						is_culture_group = italian
 						has_global_flag = the_treaty_of_milan
 						NOT = { 
 							truce_with = FRA
 							truce_with = BOR
 						}	
 					}
-					721 = { NOT = { is_core = ITA } } #Aosta
 				}
 			}
 		}
@@ -773,7 +779,7 @@ political_decisions = {
 				}
 				734 = { add_core = ITA remove_core = TST }
 				736 = { add_core = ITA }
-				owner = { set_global_flag = italian_claimed_venetia 
+				owner = { set_global_flag = italian_claimed_south_tirol 
 				}
 			}
 			
@@ -801,6 +807,8 @@ political_decisions = {
 				465 = { add_core = ITA }
 				466 = { add_core = ITA }
 				472 = { add_core = ITA }
+				owner = { set_global_flag = italian_claimed_savoia 
+				}
 			}
 			
 			#Claim Aosta
@@ -816,6 +824,8 @@ political_decisions = {
 					}
 				}
 				721 = { add_core = ITA }
+				owner = { set_global_flag = italian_claimed_aosta 
+				}
 			}
 		}
 		

--- a/PFH/decisions/Italy.txt
+++ b/PFH/decisions/Italy.txt
@@ -677,8 +677,45 @@ political_decisions = {
 				729 = { NOT = { is_core = ITA } } #Venice
 				736 = { NOT = { is_core = ITA } } #Triest
 				734 = { NOT = { is_core = ITA } } #Trient
-				721 = { NOT = { is_core = ITA } } #Aosta
-				465 = { NOT = { is_core = ITA } } #Savoia
+				AND = {
+					721 = { NOT = { is_core = ITA } } #Aosta
+					random_owned = {
+						limit = {
+							owner = {
+								is_culture_group = italian
+								has_global_flag = the_treaty_of_milan
+								NOT = { 
+									truce_with = FRA
+									truce_with = BOR
+								}	
+							}
+						}	
+					}
+				}
+				AND = {
+					465 = { NOT = { is_core = ITA } } #Savoia
+					random_owned = {
+						limit = {
+							owner = {
+								is_culture_group = italian
+								OR = {
+									NOT = { has_global_flag = plombieres }
+									has_global_flag = the_treaty_of_milan
+									has_global_flag = france_dismantled
+									has_country_flag = in_great_war
+									AND = {
+										ai = no
+										nationalism_n_imperialism = 1
+									}
+								}
+								NOT = {
+									truce_with = FRA
+									truce_with = BOR
+								}	
+							}
+						}
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
(https://github.com/moretrim/PFH/commit/415a621d688fde86f562aabb57590a12bea7de3a)
Before this fix, this complex decision became spammy until Italy achieved the situation where the core-addition effect would work for all involved provinces. The point of this decision is to add Italian cores to neighboring provinces that possess Italian pops but belong to other countries. Because the `allow` step was very simple and permissive, the ai tended to spam it as quickly as possible for many in-game years or until the end of the game. Whenever I tag-switched to Italy to see what was the matter, this decision was one among multiple allowed decisions on Italy's list. It is therefore not clear how many deleterious effects this spamming has on the game, but at least it makes the log frustrating to read, and it may reduce performance. I am not sure if ai Italy was prevented from using the other decisions on its list or not while spamming this one, but this appeared to be a possibility.

In the proposed fix, I tried to balance the `effect` with the `allow`, such that it can only be clicked when an actual effect can happen. Some additional changes were made during bug-testing, because it took a few tries to get it working: I learned some things about decisions and about what scopes are allowed in them.

(https://github.com/moretrim/PFH/commit/241ea733882b644b04046bf88441660fe600eb7c)
Things seem to have worked for Aosta and Savoy, and now the decision is fixed to stop being spammy when Trient and Triest are not yet claimed. Venice is comparably simple and apparently does not need a fix. Here I ended up needing to change more things than I had expected in order to fix the decision for Trient and Triest.

(https://github.com/moretrim/PFH/commit/931bfefb60a5560fed1798e1400fe9691b647399)
The allow statement was broken by `random_owned` but `THIS` is built to scope to Italy in cases like these. I had thought in the previous commits that `random_owned` from the `effect` statement would work in the `allow` statement, but discovered that this would not work. Therefore I scoped it using `THIS` instead. Now, the decision is no longer spammy, but it works when situations are right.

Pictorially, in subsequent playtesting:
Annecy has gotten its Italian core:
![ItaliaIrredenta](https://user-images.githubusercontent.com/17787203/69492163-6e127800-0e53-11ea-82e8-db04924e5230.png)

Triest has gotten its Italian core:
![ItaliaIrredenta](https://user-images.githubusercontent.com/17787203/69492164-78cd0d00-0e53-11ea-8331-753964b88ccb.png)