### PR TITLE
Prevent UK Call Allies to War spam when allies cannot be called

### DIFF
--- a/PFH/decisions/FlavourMod_Setup_CleanUp.txt
+++ b/PFH/decisions/FlavourMod_Setup_CleanUp.txt
@@ -162,6 +162,11 @@ political_decisions = {
 					exists = yes
 				}
 			}
+			OR = {
+				involved_in_crisis = no
+				NOT = { has_global_flag = revolution_n_counter_researched }
+				has_global_flag = great_wars_enabled
+			}
 		}
 		
 		allow = { 


### PR DESCRIPTION
In certain circumstances, such as when there is a crisis war before great wars are discovered, ai United Kingdom will spam the decision `cleanup_eic`, because its `effect` cannot resolve the conditions that trigger its `allow`. This results in spamming calls to arms to wars of aggression. The `effect` cannot do its work in the abovementioned circumstance because allies cannot be called to crisis wars until great wars are discovered. A fix for this is added in this commit, to prevent it from firing in that situation. During testing, it was found that some earlier wars, such as The Crimean War, may also count as crises. Therefore, the changes were refined to permit the decision to function for them.

The problem looks like this, where over the span of three days, the decision is spammed every day. This repeats until either the crisis war is over, or until great wars are discovered. This particular problem happens only in the time between when crisis wars are enabled (Revolution & Counterrevolution in ~1870) and the discovery of great wars (usually after 1900). This is particularly problematic if peace deals are set to initiate a pop-up. Given the timing, the problems result from trying to call the Rajputana Agency instead of the East India Company.

![UKCallAlliesSpam](https://user-images.githubusercontent.com/17787203/76982278-e1576280-68f8-11ea-81d8-e00b7e796b8e.png)

During four playthroughs of testing, the fixed decision worked every time.

This is referenced in more detail in #63