### PR TITLE
Rbx4/uk call allies spam

### DIFF
--- a/ccHFM/decisions/FlavourMod_Setup_CleanUp.txt
+++ b/ccHFM/decisions/FlavourMod_Setup_CleanUp.txt
@@ -238,7 +238,7 @@ political_decisions = {
 				   attacker_goal = {  casus_belli = call_allies_cb  }
 				   call_ally = yes
 			   }
-			}
+		}
 	}
 	
 	cleanup_morocco = {

--- a/ccHFM/decisions/FlavourMod_Setup_CleanUp.txt
+++ b/ccHFM/decisions/FlavourMod_Setup_CleanUp.txt
@@ -162,6 +162,19 @@ political_decisions = {
 					exists = yes
 				}
 			}
+			OR = {
+				NOT = { has_global_flag = revolution_n_counter_researched }
+				has_global_flag = great_wars_enabled
+				AND = {
+					has_global_flag = revolution_n_counter_researched
+					NOT = { has_global_flag = great_wars_enabled }
+					ENG = {
+						NOT = {
+							has_country_modifier = stop_spam_uk
+						}
+					}
+				}
+			}
 		}
 		
 		allow = { 
@@ -215,11 +228,17 @@ political_decisions = {
 		}
 		
 		effect = {
+			ENG = {
+				add_country_modifier = {
+					name = stop_spam_uk
+					duration = 30
+				}
+			}
 			   war = {               #No target initiates a one-day war that automatically resolves in a WP, but call_ally causes the new ally 
 				   attacker_goal = {  casus_belli = call_allies_cb  }
 				   call_ally = yes
 			   }
-		}
+			}
 	}
 	
 	cleanup_morocco = {


### PR DESCRIPTION
In certain circumstances, such as when there is a crisis war before great wars are discovered, ai United Kingdom will spam the decision `cleanup_eic`, because its `effect` cannot resolve the conditions that trigger its `allow`. This results in spamming calls to arms to wars of aggression. The `effect` cannot do its work in the abovementioned circumstance because allies cannot be called to crisis wars until great wars are discovered. A fix for this is added to prevent it from firing in that situation.

The problem looks like this, where over the spam of eight days, the decision is spammed every day. This repeats until either the crisis war is over, or until great wars are discovered. This particular problem happens only between the time between crisis wars are enabled (Revolution & Counterrevolution on or after 1870) and the discovery of great wars (usually after 1900). This is particularly problematic if peace deals are set to initiate a pop-up. Given the timing, the problems result from trying to call the Rajputana Agency instead of the East India Company.

![UKCallAlliesSpam](https://user-images.githubusercontent.com/17787203/76982278-e1576280-68f8-11ea-81d8-e00b7e796b8e.png)

Since the previous fix attempt assumed that early calls to arms were failed due to unexplained early crisis wars (this was not really the case, but instead the fix was flawed), this new attempt adds a 30-day cooldown to UK Call Allies spam, using the modifier `stop_spam_uk`. This seems potentially reasonable, although a different cooldown may be preferable.

This is referenced in more detail in #63  rbx4/UKCallAlliesSpam