### PR TITLE
World Fair planning fixed to become less spammy under certain conditions

### DIFF
--- a/ccHFM/events/WorldFairs.txt
+++ b/ccHFM/events/WorldFairs.txt
@@ -28,7 +28,7 @@ country_event = {
 		
 		modifier = {
 			factor = 0.01
-			primary_culture = french
+			tag = FRA
 			bessemer_process = 1
 			NOT = { has_country_flag = the_eiffel_tower_was_built }
 		}


### PR DESCRIPTION
While this likely occurs only under highly specific circumstances, the World's Fair planning event can become spammy for certain French primary tags such as Martinique.

This seems to be due to a modifier for tags with a French primary culture, but which do not have an Eiffel Tower built yet. The Eiffel Tower is linked to an 1889 World's Fair known as the Exposition Universelle, and the decision `build_the_eiffel_tower` requires the country flag `world_fair_planner`. This serves as evidence that the relatively extreme modifier is meant specifically for France, and not for any tags that can never build the Eiffel Tower.

While I am puzzled why `primary_culture` was used instead of `tag = FRA` in the event, there does not seem to be any problem with `tag =` being used in `ai_chance` modifier triggers. Therefore, I suggest simply changing the modifier in this way.

This is described in issue #87