### PR TITLE
World Fair planning fixed to become less spammy under certain conditions

### DIFF
--- a/ccHFM/events/WorldFairs.txt
+++ b/ccHFM/events/WorldFairs.txt
@@ -29,6 +29,7 @@ country_event = {
 		modifier = {
 			factor = 0.01
 			primary_culture = french
+			capital = 425
 			bessemer_process = 1
 			NOT = { has_country_flag = the_eiffel_tower_was_built }
 		}


### PR DESCRIPTION
While this likely occurs only under highly specific circumstances, the World's Fair planning event can become spammy for certain French primary tags such as Martinique.

This seems to be due to a modifier for tags with a French primary culture, but which do not have an Eiffel Tower built yet. The Eiffel Tower is linked to an 1889 World's Fair known as the Exposition Universelle, and the decision `build_the_eiffel_tower` requires the country flag `world_fair_planner`. This serves as evidence that the relatively extreme modifier is meant specifically for France, and not for any tags that can never build the Eiffel Tower.

I was previously puzzled over why `primary_culture` was used instead of `tag = FRA` in the event. Then I realized that France occasionally changes tags through the course of the game. Therefore, have adjusted the fix to scope France based on `primary_culture` and `capital`.

If we want to be especially funny, we could allow Martinique to build the Eiffel Tower, but I think there is no way for Martinique to annex Paris before France can build the Eiffel Tower.

This is described in issue #87