### PR TITLE
Occupation of the Congo when colonizers are not Great Powers

### DIFF
--- a/ccHFM/decisions/FlavourMod_Africa.txt
+++ b/ccHFM/decisions/FlavourMod_Africa.txt
@@ -632,24 +632,20 @@ political_decisions = {
 		potential = {
 			has_global_flag = berlin_conference
 			NOT = { has_global_flag = congo_failed }
-			is_greater_power = yes
 			OR = {
 				AND = {
-					owns = 1972
 					1976 = { empty = yes } #Gabon
 				}
 				AND = {
-					owns = 1977
 					1980 = { empty = yes } #Congo
 				}
 				AND = {
-					owns = 1981
 					1966 = { empty = yes } #Ubangi-Shari
 					1962 = { empty = no } #Cameroon
 				}	
 				AND = {
-					owns = 1967
 					1819 = { empty = yes } #Waddai
+					1967 = { empty = no }
 				}
 			}
 		}
@@ -673,11 +669,13 @@ political_decisions = {
 					1980 = { empty = yes } #Congo
 				}
 				AND = {
+					year = 1890
 					invention = the_dark_continent
 					owns = 1981
 					1966 = { empty = yes } #Ubangi-Shari
 				}
 				AND = {
+					year = 1895
 					invention = the_dark_continent
 					owns = 1967
 					1819 = { empty = yes } #Waddai
@@ -737,6 +735,7 @@ political_decisions = {
 			random_owned = {
 				limit = {
 					owner = {
+						year = 1895
 						invention = the_dark_continent
 						owns = 1967
 						1819 = { empty = yes }


### PR DESCRIPTION
In both default HFM and in the current ccHFM release, the decision [Occupation of the Congo](https://github.com/moretrim/ccHFM/blob/b332994daebf3efbde337a83f4941a456d06f44b/ccHFM/decisions/FlavourMod_Africa.txt#L629) may not be visible to anyone after Cameroon and Congo have been colonized, under certain conditions.

There are multiple conditions where this decision may not be visible due to factors in its `potential`, but one that stands out in particular is the requirement that colonizers be great powers:

https://github.com/moretrim/ccHFM/blob/b332994daebf3efbde337a83f4941a456d06f44b/ccHFM/decisions/FlavourMod_Africa.txt#L629-L635

The problem looks like this, where Ubangi-Shari, Waddai, and Chad are impossible to occupy, and the decision is invisible to all involved tags. In this particular case, the problem is that Spain should be able to invoke the decision, but it cannot because it is not a Great Power:

![image](https://user-images.githubusercontent.com/17787203/119295640-20bfc400-bc0c-11eb-88c4-cae7dce46e69.png)

While it is possible to fix the particular case seen online and in my test save, by requiring secondary power instead, there is the possibility that especially Portugal could own Impfondo (province `1981`), making even this requirement too restrictive.

I would suggest a time-gating instead. Ubangi-Shari was made part of French Congo in [1891](https://en.wikipedia.org/wiki/Ubangi-Shari). The Chad Basin was conquered in 1898 by the eventual completion of the [Voulet-Chanoine Mission](https://en.wikipedia.org/wiki/Voulet%E2%80%93Chanoine_Mission).

I suggest adding a time gate of 1890 to Ubangi-Shari, which in the `potential` is otherwise:

https://github.com/moretrim/ccHFM/blob/b332994daebf3efbde337a83f4941a456d06f44b/ccHFM/decisions/FlavourMod_Africa.txt#L645-L648

...and a time gate of of potentially 1895 for the Chad Basin, which in the potential `potential` is otherwise:

https://github.com/moretrim/ccHFM/blob/b332994daebf3efbde337a83f4941a456d06f44b/ccHFM/decisions/FlavourMod_Africa.txt#L650-L652

After making the above adjustments, I decided to take a liberty in making the `potential` more visible, so that players can know which states to take to occupy the Congo Basin for themselves. I am also somewhat amused that `year = 1895` worked inside `owner =` in the `effect` for Waddai. Testing by recreating the situation encountered online worked while playing as secondary power Spain.

This is further referenced in Issue #86 