### PR TITLE
Hudson's Bay Company to Canada

### DIFF
--- a/ccHFM/events/CANFlavor.txt
+++ b/ccHFM/events/CANFlavor.txt
@@ -1442,15 +1442,6 @@ country_event = {
 			limit = {
 				tag = RPL
 				exists = yes
-				vassal_of = FROM
-			}
-			all_core = { remove_core = RPL }
-			annex_to = CAN
-		}
-		random_country = {
-			limit = {
-				tag = RPL
-				exists = yes
 				NOT = { vassal_of = FROM }
 			}
 			any_owned = {
@@ -1479,6 +1470,26 @@ country_event = {
 				any_pop = { militancy = -6 }
 				secede_province = CAN
 			}
+		}
+		random_country = {
+			limit = {
+				tag = RPL
+				vassal_of = FROM
+				ai = no
+			}
+			all_core = { remove_core = RPL }
+			change_tag = CAN
+		}
+		random_country = {
+			limit = {
+				tag = RPL
+				vassal_of = FROM
+				ai = yes
+			}
+			all_core = { remove_core = RPL }
+		}
+		CAN = {
+			inherit = RPL
 		}
 		ai_chance = {
 			factor = 100


### PR DESCRIPTION
References issue #95 

In regular HFM, Hudson's Bay Company annexes into Canada in event `44321`, The Rupert's Land Act (Canada side). This happens even if Hudson's Bay Company is the player, without player protection or notification:

https://github.com/moretrim/ccHFM/blob/e0ee2ed03ffa2458f2d42c1409e7e7bba49dcd7a/ccHFM/events/CANFlavor.txt#L1441-L1449

There are a few ways to address this. A player option to refuse could be added, with a Free Allied Cores casus belli awarded to UK, and it could be added later as Canadian flavor.

There was an American offer to purchase the territory controlled by the Company in 1869, but this seems to be a separate topic that is again best addressed as Canadian and/or American flavor.

A simpler alternative is to alter the event to switch the player's tag from Hudson's Bay Company to Canada in this event, and this is what I have chosen. This opens a route for starting as Hudson's Bay Company with the intent of playing onward as Canada. I have tested this as the player in Hudson's Bay, and by leaving it up to the a.i.

I have also moved the older handling of a.i. puppet Hudson's Bay (`RPL`) nearer to the bottom of the `option`, so that unintended problems can be avoided: it seems best to always have anything regarding annexation occur last or nearly so. The `option` in core HFM is relatively complex, but it seems to already have provisions for handling an already independent `RPL`.

It remains possible, though difficult, to gain independence as `RPL` if rebels succeed and then the UK fails to puppet you again. As mentioned, expansion of this route would require creating a new event to ask RPL if it accepts or not. This sort of thing would probably be best done in a separate events file, with some other added flavor, to avoid cluttering core HFM files with new events.