### PR TITLE
Hejaz cannot be stolen from a great power Ottoman Empire

### DIFF
--- a/ccHFM/decisions/Arabia.txt
+++ b/ccHFM/decisions/Arabia.txt
@@ -397,6 +397,7 @@ political_decisions = {
 			NOT = { tag = TUR }
 			TUR = {
 				NOT = { has_country_flag = arab_revolt }
+				is_greater_power = no
 				any_owned_province = {
 					any_core = {
 						OR = {


### PR DESCRIPTION
The decision `encourage_arab_nationalism` releases Hejaz from the Ottoman Empire/Turkey (`TUR`) that is currently at war with a great power, after 1900 or after the `sykes_picot` flag is set upon attempting to carve up a weakened Ottoman Empire. It also places Hejaz in the sphere of the country that releases it, and forms an alliance.

Given especially the context of `sykes_picot` that requires a weakened `TUR`, I do not see why this should happen if the Ottoman Empire  has remained as a great power. It seems inappropriate to release owned land from a great power and sphering it, without first winning a war against the great power. Yet, this can happen if the year is after 1900. This scenario is as follows:

Before:
![image](https://user-images.githubusercontent.com/17787203/120931400-2dc9c200-c6a6-11eb-93e8-727489bac15a.png)

After:
![image](https://user-images.githubusercontent.com/17787203/120931496-b47e9f00-c6a6-11eb-8f9a-2b352900cb53.png)

I have added a requirement to `encourage_arab_nationalism` that it can only be used if `TUR` is not a great power.