### PR TITLE
Delay in Persian Kurdish tag autonomy revocation

### DIFF
--- a/ccHFM/decisions/Persia.txt
+++ b/ccHFM/decisions/Persia.txt
@@ -155,7 +155,8 @@ revoke_kurdish_autonomy = {
 		}
 		
 		allow = {
-			civilization_progress = 0.25
+			civilization_progress = 0.5
+			has_country_flag = cch.bedr-khan-defeated
 		}
 		
 		effect = {

--- a/ccHFM/events/Ottoman Empire.txt
+++ b/ccHFM/events/Ottoman Empire.txt
@@ -2228,6 +2228,7 @@ country_event = {
 	option = {
 		name = "EVT986505OPTA"
 		clr_country_flag = return_persian_lands_on_finish
+		PER = { set_country_flag = cch.bedr-khan-defeated }
 		any_owned = {
 			limit = {
 			OR = {

--- a/ccHFM/localisation/cch.fixes.csv
+++ b/ccHFM/localisation/cch.fixes.csv
@@ -20,3 +20,5 @@ NEW_ADJ;Newfoundland;Terre-Neuvien;Neufundländisch;;Terranovesa;;;;;;;;;
 NZL_ADJ;Kiwi;Néo-zélandais;Neuseeländisch;;Nueva Zelanda;;;;;;;;;
 # Parties #;;;;;;;;;;;;;;
 QUE_reactionary;Parti nationaliste;Parti nationaliste;Parti nationaliste;;Parti nationaliste;;;;;;;;;
+# Flags #;;;;;;;;;;;;;;
+cch.bedr-khan-defeated;Bedr Khan defeated;;;;;;;;;


### PR DESCRIPTION
References isssue #103 

The code for the decision `revoke_kurdish_autonomy` does not seem to be working as intended, based on some observations regarding the Bedr Khan Rebellion. Take for instance Bohtan upon rebellion, which does not include any part of Tabriz, nor any province that is normally part of Persia:

![image](https://user-images.githubusercontent.com/17787203/120933682-0972e300-c6b0-11eb-8eb7-d58c02c9f3de.png)

Yet, Persia's triggered war against Bohtan has war goals to Acquire Tabriz, and Acquire Luristan, but Bohtan has no province from either of these states:

![image](https://user-images.githubusercontent.com/17787203/120933776-78e8d280-c6b0-11eb-849f-0b6ac075b32c.png)

This suggests that the event chain is incomplete, and that Bohtan is meant to annex the Persian Kurdistan satellites when the event expands Bohtan. Additional evidence of this is indicated by the code in event `986503`, which attempts to annex Kurdish `any_country` to Bohtan. It includes the Persian satellites Mukriyan (`MKN`) and Ardalan (`RDL`). However, these tags, when played by the a.i., are invariably annexed to Persia by this time and their cores are replaced by Kurdistan cores.

https://github.com/moretrim/ccHFM/blob/e9e6e9bad7e585acd1b082da13b73e0374f1d6e5/ccHFM/events/Ottoman%20Empire.txt#L1969-L1984

This suggests that the early annexation of a.i. Mukriyan and Ardalan in `revoke_kurdish_autonomy` is firing prematurely. [Ardalan](https://en.wikipedia.org/wiki/Ardalan) is reported to have ended in 1865 at the earliest. [Mukriyan](https://en.wikipedia.org/wiki/Mukriyan) officially ended circa 1800, but held local [control](https://bnk.institutkurde.org/images/pdf/FR5LWJGXKM.pdf) of its area until World War I.

It is realistic to believe that Bedr Khan should have control of the Persian Kurdish cores, given mention that he extended his control to [Mahabad](https://en.wikipedia.org/wiki/History_of_the_Kurds#Bedr_Khan_of_Botan), and therefore it seems appropriate to annex them to Bohtan, and then to return them to Persia after the rebellion. This does not happen to a player controlled Ardalan or Mukriyan, which both already have protection against annexation by involved decisions and events.

One reason to fix this is that it makes intuitive sense to take Tabriz early as the Ottoman Empire, but the surprising results of the post-rebellion event make the retained provinces potentially inaccessible to the Ottomans. If Mukriyan continues to survive until at least the rebellion is defeated, the player can better know when to take Tabriz.

This commit delays `revoke_kurdish_autonomy` until at least after Bohtan has been annexed, at most until Persia reaches 50% westernization progress. The westernization progress change is followed from the unfinished HFM 1.28 development branch.

During testing as an observer, Bohtan looks good with the fix in place. After the war, the Kurdish tags are not present anymore:

![image](https://user-images.githubusercontent.com/17787203/120948315-d43db380-c6f6-11eb-8d33-9e7dfaa5ea43.png)

Player protection remains for Persian Kurdish tags during Bohtan formation:

![image](https://user-images.githubusercontent.com/17787203/120948874-056ab380-c6f8-11eb-9950-a22260e193ba.png)

and it is retained for when Persia reaches 50% westernization, which is good, since this is the only reliable way to make Kurdistan in my experience:
![image](https://user-images.githubusercontent.com/17787203/120953772-99417d00-c702-11eb-9af2-b4a100f868ba.png)
