### PR TITLE
Easier discovery of modern cavalry for westernized tags

### DIFF
--- a/ccHFM/inventions/army_inventions.txt
+++ b/ccHFM/inventions/army_inventions.txt
@@ -1181,6 +1181,10 @@ cuirassier_activation = {
 			factor = -2
 			not = { civilized = yes }
 		}
+		modifier = {
+			factor = 98
+			civilized = yes
+		}
 	}
 	effect = {
 		activate_unit = cuirassier
@@ -1194,6 +1198,10 @@ dragoon_activation = {
 			factor = -2
 			not = { civilized = yes }
 		}
+		modifier = {
+			factor = 98
+			civilized = yes
+		}
 	}
 	effect = {
 		activate_unit = dragoon
@@ -1206,6 +1214,10 @@ hussar_activation = {
 		modifier = {
 			factor = -2
 			not = { civilized = yes }
+		}
+		modifier = {
+			factor = 98
+			civilized = yes
 		}
 	}
 	effect = {


### PR DESCRIPTION
References #107 

The 2% discovery rate for hussars (especially) seems draconian, especially considering that it is possible in-game to discover tanks and airplanes before discovering modern cavalry. This fix addresses the problem by making the discovery rate 100% for westernized tags that have `military_staff_system`. This seems appropriate since hussars may have historical origins as early as the late 14th century.

The operative part of the code to fix is here, adding a 98 modifier for westernized tags:

https://github.com/moretrim/ccHFM/blob/e9e6e9bad7e585acd1b082da13b73e0374f1d6e5/ccHFM/inventions/army_inventions.txt#L1202-L1214

Optionally, a there could be added a non-zero chance for non-westernized tags to discover them under certain reforms, but I have not added this.