### PR TITLE
Deseret/USA remain theocracies if formed/released as such

### DIFF
--- a/ccHFM/events/CleanUp.txt
+++ b/ccHFM/events/CleanUp.txt
@@ -1074,6 +1074,8 @@ country_event = {
 		NOT = { tag = SUD }
 		NOT = { tag = TPG }
 		NOT = { tag = MGL }
+		NOT = { tag = DES }
+		NOT = { tag = USA }
 	}
 
 	mean_time_to_happen = { months = 1 }


### PR DESCRIPTION
Deseret has the bizarre status of starting out as a theocracy but immediately flipping to monarchy as part of a cleanup event.

This PR modifies the relevant event so that Deseret is allowed to remain a theocracy. Furthermore, if Deseret somehow forms USA, that USA should also be permitted to remain a theocracy, similar to theocratic Italy and Yugoslavia.
