### PR TITLE
Italo-Turkish War issue fixes

### DIFF
--- a/ccHFM/events/ItaloTurkishWar.txt
+++ b/ccHFM/events/ItaloTurkishWar.txt
@@ -307,11 +307,26 @@ country_event = {
 		set_global_flag = italy_fights_turk
 		diplomatic_influence = { who = TUR value = -400 }
 		relation = { who = TUR value = -400 }
-		CYR = { all_core = { add_core = LBY remove_core = CYR } }
-		TRI = { all_core = { add_core = LBY remove_core = TRI } }
+		any_country = { limit = { tag = CYR exists = no } all_core = { add_core = LBY remove_core = CYR } }
+		any_country = { limit = { tag = TRI exists = no } all_core = { add_core = LBY remove_core = TRI } }
+		TUR = {
+			add_casus_belli = {
+				target = ITA
+				type = place_in_the_sun
+				months = 12
+			}
+		}
+		TUR = {
+			add_casus_belli = {
+				target = ITA
+				type = place_in_the_sun
+				months = 12
+			}
+		}
 		war = {
 			target = TUR
-			attacker_goal = { casus_belli = liberate_country country = LBY }
+			attacker_goal = { casus_belli = place_in_the_sun state_province_id = 1735 }
+			attacker_goal = { casus_belli = place_in_the_sun state_province_id = 1731 }
 		}
 		
 		ai_chance = {


### PR DESCRIPTION
References issue #136, which describes three main issues with the Italo-Turkish War over Libya, and with event `900007` in particular.

Event [900007 ](https://github.com/moretrim/ccHFM/blob/4b35adddc23a0281b7da37ee3b71654191fe2b75/ccHFM/events/ItaloTurkishWar.txt#L296-L376) `Turks Refuse`, now grants two `place_in_the_sun` casus bellorum to Italy, to avoid hidden infamy costs, instead of starting the war with a `liberate_country` casus belli. The war is started with `TUR` by targeting Tripolitania and Cyrenaica using these casus bellorum. While the in-game pop-up message does not indicate the targeting, it works in the war screen and in the war itself. Removal of Tripoli and `CYR` cores in this event now only works when the respective tag does not exist.

A commented [EVTOPTB900007](https://github.com/moretrim/ccHFM/blob/4b35adddc23a0281b7da37ee3b71654191fe2b75/ccHFM/events/ItaloTurkishWar.txt#L345-L376) from regular HFM was noticed and left as-is. The current infamy cost for the Italo-Turkish War is reduced to the 3 infamy cost in Event [900002](https://github.com/moretrim/ccHFM/blob/4b35adddc23a0281b7da37ee3b71654191fe2b75/ccHFM/events/ItaloTurkishWar.txt#L146-L192), instead of the previous 15.1 infamy total cost.