### PR TITLE
British Dominion release events are retuned to be less spammy

### DIFF
--- a/ccHFM/common/event_modifiers.txt
+++ b/ccHFM/common/event_modifiers.txt
@@ -3309,6 +3309,10 @@ cch.recent-call-to-arms = {
     icon = 15
 }
 
+cch.colonial-conference-cooldown = {
+	icon = 5
+}
+
 ## Country Workshop
 
 country-workshop.hanseatic-tooltip0 = {

--- a/ccHFM/events/BritishDominions.txt
+++ b/ccHFM/events/BritishDominions.txt
@@ -15,9 +15,12 @@ country_event = {
             tag = ENL
         }
 		war = no
-		year = 1907
+		year = 1890
 		any_owned_province = { is_core = NEW }
-		NOT = { exists = NEW }
+		NOT = {
+			exists = NEW
+			has_country_modifier = cch.colonial-conference-cooldown
+		}
 		is_possible_vassal = NEW
 	}
 
@@ -137,6 +140,10 @@ country_event = {
 	option = {
 		name = "EVT44330OPTB"
 		set_country_flag = NEW_independence_refused
+		add_country_modifier = {
+			name = cch.colonial-conference-cooldown
+			duration = 1000
+		}
 		any_owned = {
 			limit = { is_core = NEW }
 			any_pop = {
@@ -272,9 +279,12 @@ country_event = {
             tag = ENL
         }
 		war = no
-		year = 1901
+		year = 1900
 		any_owned_province = { is_core = AST }
-		NOT = { exists = AST }
+		NOT = {
+			exists = AST
+			has_country_modifier = cch.colonial-conference-cooldown
+		}
 		is_possible_vassal = AST
 	}
 
@@ -385,6 +395,10 @@ country_event = {
 	option = {
 		name = "EVT44330OPTB"
 		set_country_flag = AST_independence_refused
+		add_country_modifier = {
+			name = cch.colonial-conference-cooldown
+			duration = 1000
+		}
 		any_owned = {
 			limit = { is_core = AST }
 			any_pop = {
@@ -482,7 +496,10 @@ country_event = {
 		war = no
 		year = 1907
 		any_owned_province = { is_core = NZL }
-		NOT = { exists = NZL }
+		NOT = {
+			exists = NZL
+			has_country_modifier = cch.colonial-conference-cooldown
+		}
 		is_possible_vassal = NZL
 	}
 
@@ -516,6 +533,10 @@ country_event = {
 	option = {
 		name = "EVT44330OPTA"
 		clr_country_flag = NZL_independence_refused
+		add_country_modifier = {
+			name = cch.colonial-conference-cooldown
+			duration = 1000
+		}
 		prestige = -15
 		badboy = -3
 		any_pop = {
@@ -698,7 +719,10 @@ country_event = {
 		war = no
 		year = 1909
 		any_owned_province = { is_core = SAF }
-		NOT = { exists = SAF }
+		NOT = {
+			exists = SAF
+			has_country_modifier = cch.colonial-conference-cooldown
+		}
 		is_possible_vassal = SAF
 	}
 
@@ -826,6 +850,10 @@ country_event = {
 	option = {
 		name = "EVT44330OPTB"
 		set_country_flag = SAF_independence_refused
+		add_country_modifier = {
+			name = cch.colonial-conference-cooldown
+			duration = 1000
+		}
 		any_owned = {
 			limit = { is_core = SAF }
 			any_pop = {
@@ -1360,7 +1388,10 @@ country_event = {
 		CAN = { war = no }
 		is_our_vassal = CAN
 		year = 1880
-		NOT = { capital_scope = { continent = north_america } }
+		NOT = {
+			capital_scope = { continent = north_america }
+			has_country_modifier = cch.colonial-conference-cooldown
+		}
 		any_owned_province = {
 			region = USA_1
 			controlled_by = THIS
@@ -1425,6 +1456,10 @@ country_event = {
 	
 	option = {
 		name = "EVT44340OPTC"
+		add_country_modifier = {
+			name = cch.colonial-conference-cooldown
+			duration = 1000
+		}
 		USA_1 = {
 			remove_core = THIS
 		}
@@ -1486,6 +1521,7 @@ country_event = {
 		war = no
 		year = 1924
 		any_owned_province = { is_core = RHO }
+		NOT = { has_country_modifier = cch.colonial-conference-cooldown }
 	}
 
 	mean_time_to_happen = {
@@ -1588,6 +1624,10 @@ country_event = {
 	option = {
 		name = "EVT44330OPTB"
 		set_country_flag = RHO_independence_refused
+		add_country_modifier = {
+			name = cch.colonial-conference-cooldown
+			duration = 1000
+		}
 		any_owned = {
 			limit = { is_core = RHO }
 			any_pop = { militancy = 3 }

--- a/ccHFM/events/CANFlavor.txt
+++ b/ccHFM/events/CANFlavor.txt
@@ -325,20 +325,19 @@ country_event = {
 			tag = ENL
 		}
 		war = no
-		year = 1867
+		year = 1865
 		any_owned_province = { is_core = CAN }
-		NOT = { exists = CAN }
+		NOT = {
+			exists = CAN
+			has_country_modifier = cch.colonial-conference-cooldown
+		}
 		is_possible_vassal = CAN
 	}
 
 	mean_time_to_happen = {
 		months = 6
 		modifier = {
-			factor = 15
-			has_country_flag = CAN_independence_refused
-		}
-		modifier = {
-			factor = 3
+			factor = 1.5
 			NOT = { has_country_flag = charlottetown_conference }
 		}
 		modifier = {
@@ -349,9 +348,17 @@ country_event = {
 			}
 		}
 		modifier = {
-			factor = 0.5
-			year = 1870
-			NOT = { has_country_flag = CAN_independence_refused }
+			factor = 0.1
+			OR = {
+				has_global_flag = american_civil_war_has_happened
+				has_global_flag = alt_american_civil_war_has_happened
+			}
+			USA = {
+				trade_policy = protectionism
+				war = no
+				has_recently_lost_war = no
+				has_country_flag = hasmanifestdestiny
+			}
 		}
 	}
 
@@ -442,18 +449,30 @@ country_event = {
 				factor = 1.2
 				militancy = 5
 			}
-			
+			modifier = {
+				factor = 2
+				OR = {
+					has_global_flag = american_civil_war_has_happened
+					has_global_flag = alt_american_civil_war_has_happened
+				}
+				USA = {
+					trade_policy = protectionism
+					war = no
+					has_recently_lost_war = no
+					has_country_flag = hasmanifestdestiny
+				}
+			}
 		}	
 	}
 	option = {
 		name = "EVT44315OPTB"
 		set_country_flag = CAN_independence_refused
+		add_country_modifier = {
+			name = cch.colonial-conference-cooldown
+			duration = 1000
+		}
 		any_owned = {
 			limit = { is_core = CAN }
-			add_province_modifier = {
-				name = nationalist_agitation
-				duration = 1095
-			}
 			any_pop = {
 				limit = { has_pop_culture = anglo_canadian }
 				militancy = 3
@@ -559,16 +578,15 @@ country_event = {
 			}
 		}
 		any_owned_province = { is_core = QUE }
-		NOT = { exists = QUE }
+		NOT = {
+			exists = QUE
+			has_country_modifier = cch.colonial-conference-cooldown
+		}
 		is_possible_vassal = QUE
 	}
 
 	mean_time_to_happen = {
-		months = 12
-		modifier = {
-			factor = 10
-			has_country_flag = QUE_independence_refused
-		}
+		months = 6
 		modifier = {
 			factor = 0.8
 			any_state = {
@@ -665,6 +683,10 @@ country_event = {
 	option = {
 		name = "EVT44315OPTB"
 		set_country_flag = QUE_independence_refused
+		add_country_modifier = {
+			name = cch.colonial-conference-cooldown
+			duration = 1000
+		}
 		any_owned = {
 			limit = { is_core = QUE }
 			add_province_modifier = {
@@ -779,7 +801,10 @@ country_event = {
 			}
 		}
 		any_owned_province = { is_core = MRU }
-		NOT = { exists = MRU }
+		NOT = {
+			exists = MRU
+			has_country_modifier = cch.colonial-conference-cooldown
+		}
 		is_possible_vassal = MRU
 	}
 
@@ -890,6 +915,10 @@ country_event = {
 	option = {
 		name = "EVT44315OPTB"
 		set_country_flag = MRU_independence_refused
+		add_country_modifier = {
+			name = cch.colonial-conference-cooldown
+			duration = 1000
+		}
 		any_owned = {
 			limit = { is_core = MRU }
 			add_province_modifier = {
@@ -898,8 +927,8 @@ country_event = {
 			}
 			any_pop = {
 				limit = { has_pop_culture = anglo_canadian }
-				militancy = 6
-				consciousness = 6
+				militancy = 3
+				consciousness = 5
 			}
 		}
 		ai_chance = {
@@ -1018,11 +1047,14 @@ country_event = {
 				}
 			}
 		}
-		NOT = { exists = COL }
+		NOT = {
+			exists = COL
+			has_country_modifier = cch.colonial-conference-cooldown
+		}
 	}
 
 	mean_time_to_happen = {
-		months = 36
+		months = 24
 		modifier = {
 			factor = 10
 			has_country_flag = COL_independence_refused
@@ -1141,6 +1173,10 @@ country_event = {
 	option = {
 		name = "EVT44315OPTB"
 		set_country_flag = COL_independence_refused
+		add_country_modifier = {
+			name = cch.colonial-conference-cooldown
+			duration = 1000
+		}
 		any_owned = {
 			limit = { is_core = COL }
 			add_province_modifier = {
@@ -1149,8 +1185,8 @@ country_event = {
 			}
 			any_pop = {
 				limit = { has_pop_culture = anglo_canadian }
-				militancy = 6
-				consciousness = 6
+				militancy = 3
+				consciousness = 5
 			}
 		}
 		ai_chance = {

--- a/ccHFM/events/FlavourMod_FRA_Dominions.txt
+++ b/ccHFM/events/FlavourMod_FRA_Dominions.txt
@@ -14,7 +14,10 @@ country_event = {
 		war = no
 		year = 1867
 		any_owned_province = { is_core = FCA }
-		NOT = { exists = FCA }
+		NOT = {
+			exists = FCA
+			has_country_modifier = cch.colonial-conference-cooldown
+		}
 		AND = {
 			has_country_flag = acadia_organized 
 			has_country_flag = canada_organized
@@ -114,6 +117,10 @@ country_event = {
 	option = {
 		name = "EVT99802OPTB"
 		set_country_flag = FCA_independence_refused
+		add_country_modifier = {
+			name = cch.colonial-conference-cooldown
+			duration = 1000
+		}
 		any_owned = {
 			limit = { is_core = FCA }
 			any_pop = {
@@ -206,7 +213,10 @@ country_event = {
 		war = no
 		year = 1890
 		any_owned_province = { is_core = NZF }
-		NOT = { exists = NZF }
+		NOT = {
+			exists = NZF
+			has_country_modifier = cch.colonial-conference-cooldown
+		}
 		has_global_flag = french_nzl
 		is_possible_vassal = NZF
 	}
@@ -318,6 +328,10 @@ country_event = {
 	option = {
 		name = "EVT99802OPTB"
 		set_country_flag = NZF_independence_refused
+		add_country_modifier = {
+			name = cch.colonial-conference-cooldown
+			duration = 1000
+		}
 		any_owned = {
 			limit = { is_core = NZF }
 			any_pop = {
@@ -408,7 +422,10 @@ country_event = {
 		war = no
 		year = 1870
 		any_owned_province = { is_core = ULA }
-		NOT = { exists = ULA }
+		NOT = {
+			exists = ULA
+			has_country_modifier = cch.colonial-conference-cooldown
+		}
 		has_country_flag = louisiana_organized
 		ULA = {
 			all_core = {
@@ -535,6 +552,10 @@ country_event = {
 	option = {
 		name = "EVT99802OPTB"
 		set_country_flag = ULA_independence_refused
+		add_country_modifier = {
+			name = cch.colonial-conference-cooldown
+			duration = 1000
+		}
 		any_owned = {
 			limit = { is_core = ULA }
 			any_pop = {

--- a/ccHFM/localisation/cch.fixes.csv
+++ b/ccHFM/localisation/cch.fixes.csv
@@ -34,3 +34,5 @@ restore_america;Acquire American Core;Prendre territoire clé;Kernprovinz erwerbe
 restore_america_short;Acquire $STATE$;Prendre $STATE$;$STATE$ erwerben;;;;;;;;;;;
 restore_america_setup;Acquire American core $STATE$ from $RECIPIENT$;Prendre État clé $STATE$ de $RECIPIENT$;Kern-$STATE$ von $RECIPIENT$ erwerben;;;;;;;;;;;
 restore_america_desc;Acquire an enemy §Ystate§W with the goal of §Yrestoring the United States§W;Prendre un §YÉtat§W ennemi où nous avons des §Yprovinces principales§W;Erobern Sie einen feindlichen §YStaat§W, in dem wir §YKernprovinzen§W haben.;;;;;;;;;;;
+cch.colonial-conference-cooldown;Too many colonial conferences;;;;;;;;;;;;;;
+cch.colonial-conference-cooldown_desc;Colonies cannot ask us for independence every day.;;;;;;;;;;;;;


### PR DESCRIPTION
References #96 

The decrease in dominion-release related event spam is accomplished through the addition of a blank country modifier that enforces a 1000-day cooldown. This cooldown agrees approximately with the time between historical British Colonial Conferences. If a dominion is released, the cooldown is not incurred. If release is refused, the cooldown is incurred.

This change was done because of the excessive amount of times that dominion release events repeat when Newfoundland is owned, most notoriously, but also for other held territories as well that are meant to be eventually released as British dominions. Additionally, the pressure to release dominions seemed to be misinterpreted by the code, which suggested that rebellions would otherwise soon occur. Instead, these events were more orderly historically, with real pressures but not incipient rebellion at the time of release.

Some of these events, especially Canadian, are retuned to take into account historical factors leading to the concept of British Dominions. Some militancy and consciousness effects of release refusal are toned down to be more realistic given the relatively orderly establishment of British dominions historically. Others are less modified, because I believe that once Canada had become a dominion, it made further dominions much more likely.

In the course of addressing the cited issue, I noticed that event `999100` "#Imperial Conference 1907" exists already. This suggests to me that, despite the titles, most dominion release events are meant to simulate cases where colonies were given self-rule due to the concept of responsible government. The switch to dominions occurs in `999100` for most.