### PR TITLE
Event 99101 is changed to occur when the player is Afghanistan

### DIFF
--- a/ccHFM/events/FlavourMod_GreatGameEvt.txt
+++ b/ccHFM/events/FlavourMod_GreatGameEvt.txt
@@ -80,7 +80,6 @@ country_event = {
 		tag = ENG
 		AFG = {
 			vassal_of = ENG
-			ai = yes
 		}
 		NOT = { has_global_flag = graveyard_of_empires }
 	}
@@ -115,6 +114,8 @@ country_event = {
 			}
 			militancy = 0.5
 			consciousness = 2.5
+		}
+		AFG = { country_event = 4000000 }
 		}
 		ai_chance = {
 			factor = 100

--- a/ccHFM/events/cch.missing_notifications.txt
+++ b/ccHFM/events/cch.missing_notifications.txt
@@ -1,0 +1,12 @@
+country_event { #notify Afghanistan that 99101 occurred
+	id = 4000000
+	title = "EVTNAME99101"
+	desc = "EVTDESC99101"
+	picture = "graveyard_of_empires"
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVTOPTA500061" #Excellent
+	}
+}


### PR DESCRIPTION
References #143 

Event `99101` was problematic because there was no reason for the player to expect it to be ai-only. I have changed this to no longer be the case.

Additionally, I have added a new events file to provide notifications to tags that experience flavor involving other tags in older code, without having previously been notified by it. I expect to use this file for other missing notifications, for the Trucial States and other tags that are impacted by older flavor code, especially. For instance, the Trucial States are never notified that Bahrain and Qatar have been annexed to them.

This file will likely see heavy use from `ENG` flavor, although most likely France flavor and other older code may need to use it. I have done this in order to avoid adding problematic event numbers to older files. I have chosen `4000000` as the starting event number, since 4 resembles P for "Player notifications."