### PR TITLE
Heiqi Jun to the proper owner

### DIFF
--- a/ccHFM/decisions/FlavourMod_Qing.txt
+++ b/ccHFM/decisions/FlavourMod_Qing.txt
@@ -1246,6 +1246,7 @@ political_decisions = {
 				truce_with = THIS
 			}
 			truce_with = QNG
+			has_country_flag = cch.annex-hqj
 			NOT = { exists = DAI }
 			NOT = { has_global_flag = treaty_of_tientsin_france }
 		}
@@ -1256,6 +1257,7 @@ political_decisions = {
 		
 		effect = {
 			set_global_flag = treaty_of_tientsin_france
+			clr_country_flag = cch.annex-hqj
 			prestige = 5
 			badboy = 1
 			QNG = {

--- a/ccHFM/events/FlavourMod_China.txt
+++ b/ccHFM/events/FlavourMod_China.txt
@@ -260,6 +260,7 @@ country_event = {
 		1371 = { add_core = HQJ }
 		1372 = { add_core = HQJ }
 		casus_belli = { target = QNG type = release_puppet months = 36 }
+		set_country_flag = cch.annex-hqj
 		release = HQJ
 		HQJ = {
 			define_general = {


### PR DESCRIPTION
References #147 

In the follow ups to event 999951 "The Black Flag Army", Heiqi Jun is released and a war begins with the previous owner of colonial Tonkin. There is an issue with the resolution of this war, in that anyone with a Qing truce may take Tonkin in the decision treaty_of_tientsin_france.

In one of the more egregious examples of this bug, satellite Norway can be awarded Tonkin instead of overlord Sweden:

![TientsinBug](https://user-images.githubusercontent.com/17787203/154774567-6e14a318-b42a-4d06-8967-748340cca99a.png)

Fortunately, there is a relatively easy fix to this, to add a flag to the country that experiences event 99951, and then to verify the flag in the decision.

A flag is added to the country that owns Tonkin in the Black Flag Army event. This flag is used to award Tonkin to the proper owner if Qing is defeated:

![TientsinBug2](https://user-images.githubusercontent.com/17787203/154774582-f657bb85-c7a3-4e7a-b337-258d4b2ab38f.png)