### PR TITLE
Add a player option to prevent Fokker Aeroplanbau from moving Germany's capital

### DIFF
--- a/ccHFM/events/FlavourMod_GER.txt
+++ b/ccHFM/events/FlavourMod_GER.txt
@@ -1090,10 +1090,16 @@ country_event = {
 			}
 			owner = { capital = 619 }
 		}
+		ai_chance = {
+			factor = 1.0
+		}
 	}
 	option = {
 		name = "EVT99814OPTB"
 		set_country_flag = fokker
+		ai_chance = {
+			factor = 0
+		}
 	}
 }
 

--- a/ccHFM/events/FlavourMod_GER.txt
+++ b/ccHFM/events/FlavourMod_GER.txt
@@ -1091,6 +1091,10 @@ country_event = {
 			owner = { capital = 619 }
 		}
 	}
+	option = {
+		name = "EVT99814OPTB"
+		set_country_flag = fokker
+	}
 }
 
 #Brother's War Cleanup

--- a/ccHFM/localisation/cch.fixes.csv
+++ b/ccHFM/localisation/cch.fixes.csv
@@ -34,3 +34,4 @@ restore_america;Acquire American Core;Prendre territoire clé;Kernprovinz erwerbe
 restore_america_short;Acquire $STATE$;Prendre $STATE$;$STATE$ erwerben;;;;;;;;;;;
 restore_america_setup;Acquire American core $STATE$ from $RECIPIENT$;Prendre État clé $STATE$ de $RECIPIENT$;Kern-$STATE$ von $RECIPIENT$ erwerben;;;;;;;;;;;
 restore_america_desc;Acquire an enemy §Ystate§W with the goal of §Yrestoring the United States§W;Prendre un §YÉtat§W ennemi où nous avons des §Yprovinces principales§W;Erobern Sie einen feindlichen §YStaat§W, in dem wir §YKernprovinzen§W haben.;;;;;;;;;;;
+EVT99814OPTB;We do not believe that you can return our capital to the right place.;;;;;;;;;;;;;;


### PR DESCRIPTION
References #150 

Adds an option to event `99814` "Fokker Aeroplanbau," to avoid the effect where it moves the capital back and forth. This is done in the original event because that is the only way to place a factory at the desired location, although it does not always anticipate where to place the capital once it is done. If Germany has been formed by the player in an unusual way, such as with Baden, the player may not wish to have the capital moved to Berlin, for instance. This gives the player an option to refuse to move the capital.

I examined other code to find other events that may do this. I found some for the United Kingdom that I left alone, because London should be the only valid option for the capital to be placed at. Other cases for Germany were vanilla decisions, which probably require a different fix and arguably are a different issue.

An ai chance is added that should choose the original option every time, so that it does not miss out on its airplane factory.