### PR TITLE
Make inherit_ryukyu be regulated mainly by the allow and not the potential

### DIFF
--- a/ccHFM/decisions/Japan.txt
+++ b/ccHFM/decisions/Japan.txt
@@ -1246,18 +1246,8 @@ political_decisions = {
 		potential = {
 			OR = {
 				tag = QNG
-				AND = {
-					tag = JAP
-					has_country_modifier = fukoku_kyohei
-					OR = {
-						has_country_flag = taiwan_line_of_advantage
-						revolution_n_counterrevolution = 1
-					}
-				}
-				AND = {
-					tag = TKG
-					has_country_modifier = fukoku_kyohei
-				}
+				tag = JAP
+				tag = TKG
 			}
 			exists = RYU
 			NOT = { has_global_flag = ryukyu_inherited }
@@ -1271,6 +1261,21 @@ political_decisions = {
 			OR = {
 				RYU = { part_of_sphere = no }
 				RYU = { in_sphere = THIS }
+			}
+			OR = {
+				tag = QNG
+				AND = {
+					tag = JAP
+					has_country_modifier = fukoku_kyohei
+					OR = {
+						has_country_flag = taiwan_line_of_advantage
+						revolution_n_counterrevolution = 1
+					}
+				}
+				AND = {
+					tag = TKG
+					has_country_modifier = fukoku_kyohei
+				}
 			}
 		}
 


### PR DESCRIPTION
References #152 

As a request from someone else who played as Japan, I intend to move much of the `potential` to the `allow`, while keeping the value of the `potential` as a gatekeeper for visibility. The point of this is to make the requirements for annexing Ryukyu more visible, so that the player can better plan to do this effectively. Player protection remains.

Specifically, I mean this text:

https://github.com/moretrim/ccHFM/blob/47becfb5ccb5c1e4786bb500f718b524df991b20/ccHFM/decisions/Japan.txt#L1247-L1261

The potential has a section added to ensure that only Qing, Japan, and Tokugawa Japan can see it.