### PR TITLE
Adjusts culture acceptance for Theocratic Yugoslavia based on Orthodox religion

### DIFF
--- a/ccHFM/decisions/Balkans.txt
+++ b/ccHFM/decisions/Balkans.txt
@@ -640,13 +640,13 @@ political_decisions = {
 				limit = { owner = { accepted_culture = north_italian } }
 				owner = { remove_accepted_culture = north_italian }
 			}
+			add_accepted_culture = serb
+			add_accepted_culture = montenegrin
 			random_owned = {
 				limit = { owner = { NOT = { government = theocracy } } }
 				owner = {
-					add_accepted_culture = serb
 					add_accepted_culture = croat
 					add_accepted_culture = slovene
-					add_accepted_culture = montenegrin
 				}
 			}
 			change_tag = YUG
@@ -1374,6 +1374,7 @@ political_decisions = {
 		}
 		
 		allow = {
+			NOT = { government = theocracy }
 			prestige = 50
 			nationalism_n_imperialism = 1
 			NOT = {
@@ -1415,7 +1416,6 @@ political_decisions = {
 		}
 		
 		allow = {
-			NOT = { government = theocracy }
 			citizenship_policy = full_citizenship
 			citizens_rights = all_voting_pops
 			prestige = 50

--- a/ccHFM/events/NationalUnification.txt
+++ b/ccHFM/events/NationalUnification.txt
@@ -1253,6 +1253,7 @@ country_event = {
 		BOS = { all_core = { add_core = YUG } }
 		SLO = { all_core = { add_core = YUG } }
 		add_accepted_culture = serb
+		add_accepted_culture = montenegrin
 		add_accepted_culture = croat
 		add_accepted_culture = slovene
 		change_tag = YUG


### PR DESCRIPTION
References #154 

All formed Yugoslavia now accept Serbian and Montenegrin. Theocratic Yugoslavia can now accept Bulgarian with a decision.

When Montenegro forms Yugoslavia as a theocracy, it results in Theocratic Yugoslavia. In current code, Theocratic Yugoslavia is excluded from accepting most available cultures for Yugoslavia. As far as I know, it is limited to two: Montenegrin, and Bosniak.

The expected result of this could be that it should be an Orthodox Christian-dominated Yugoslavia. With this expectation in place, I suggest that accepted `south_slavic` cultures should at least include other chiefly Orthodox cultures, such as Serbian, and that if some are excluded, they should also follow religious differences.

That said, I'm not at all sure what to do about predominantly Catholic cultures, such as Croatian or Slovene. I suppose a theocracy probably would not accept cultures that are not exactly the same religion as theirs, although I am willing to hear alternative viewpoints.

So to try to track relevant cultures for Theocratic Yugoslavia:

Accepted cultures:
Bulgarian - predominantly Orthodox
Montenegrin - predominantly Orthodox
Serbian - predominantly Orthodox

Non-accepted cultures:
Albanian - predominantly Sunni
Bosniak - predominantly Sunni
Croatian - predominantly Catholic
Slovene - predominantly Catholic

Based on the above reasoning, I have prevented `embrace_bosnians_YUG` for Theocratic Yugoslavia, and enabled `embrace_bulgarians_YUG`. I have also added Serbian and Montenegrin as accepted.
